### PR TITLE
feat(claude): block javaNN prefix on go/bun/npm/npx via PreToolUse hook

### DIFF
--- a/dotfiles/.claude/settings.json
+++ b/dotfiles/.claude/settings.json
@@ -61,6 +61,15 @@
             "command": "automated-tasks agent hook notify"
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.command // empty' | grep -Eq '(^|[;&|]|[[:space:]])java(8|17|21|25)[[:space:]]+(go|bun|npm|npx)([[:space:]]|$)' && { echo 'Hook: drop the javaNN prefix on go/bun/npm/npx; run it bare to avoid re-sandboxing (PTY/gpg/loopback).' >&2; exit 2; }; exit 0"
+          }
+        ]
       }
     ],
     "SessionEnd": [

--- a/dotfiles/.claude/settings.json
+++ b/dotfiles/.claude/settings.json
@@ -67,7 +67,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "jq -r '.tool_input.command // empty' | grep -Eq '(^|[;&|]|[[:space:]])java(8|17|21|25)[[:space:]]+(go|bun|npm|npx)([[:space:]]|$)' && { echo 'Hook: drop the javaNN prefix on go/bun/npm/npx; run it bare to avoid re-sandboxing (PTY/gpg/loopback).' >&2; exit 2; }; exit 0"
+            "command": "jq -r '.tool_input.command // empty' | grep -Eq '(^|[;&|(])[[:space:]]*java(8|17|21|25)[[:space:]]+(go|bun|npm|npx)([[:space:]]|$)' && { echo 'Hook: drop the javaNN prefix on go/bun/npm/npx; run it bare to avoid re-sandboxing (PTY/gpg/loopback).' >&2; exit 2; }; exit 0"
           }
         ]
       }


### PR DESCRIPTION
## Summary

A `javaNN` prefix (`java8`/`java17`/`java21`/`java25`) on a non-JVM command
(`go`/`bun`/`npm`/`npx`) becomes the leading token and defeats that command's
`sandbox.excludedCommands` match, re-sandboxing it. That blocks PTY creation, the
gpg-agent socket, and loopback, so e.g. `java25 go test ...` fails with
`create pty: operation not permitted` and gpg signing errors, while the bare
`go test ...` passes.

This adds a `Bash` `PreToolUse` hook that catches the pattern and blocks it
(`exit 2`) with a message to re-run bare. It enforces the JDK-only-prefix guidance
in `CLAUDE.md` (scoped in 2d82bea) instead of relying on it being remembered.

## Scope

- **Blocks:** `javaNN go|bun|npm|npx ...` (non-JVM tools that don't need a JDK).
- **Allows (unchanged):** `javaNN mvn|gradle|java ...` and **`make`**. Maven/Gradle/
  `java` need the JDK, and some `make` targets internally run JVM builds, so a
  `javaNN make ...` prefix can be legitimate.
- Inline guard in the already-stowed `settings.json` (no new hook script/dir/symlink);
  added as a second `PreToolUse` entry next to the existing notify hook.

## Verification

Simulated the hook's jq+regex against representative inputs:

| Command | Result |
|---|---|
| `java25 go test` / `java21 npm run build` / `java17 bun ... test` | blocked |
| `java25 mvn verify` / `java25 gradle build` / `java25 make test` | allowed |
| bare `go test` / `myjava25 go` (word boundary) | allowed |

`jq -e .` confirms `settings.json` stays valid JSON.
